### PR TITLE
Added python version 3.11 to github actions build

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
It would be great if you could release a new or update the current version with version 3.11 support.